### PR TITLE
(build) Bump version of Cake used to perform build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.22.2"
+$CakeVersion = "0.32.1"
 $DotNetChannel = "preview";
 $DotNetVersion = "2.1.101";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$CAKE_PATHS_TOOLS
 NUGET_EXE=$CAKE_PATHS_TOOLS/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-CAKE_VERSION=0.22.2
+CAKE_VERSION=0.32.1
 CAKE_EXE=$TOOLS_DIR/Cake.$CAKE_VERSION/Cake.exe
 
 # Define default arguments.


### PR DESCRIPTION
- Since you are using the "latest" version fo Cake.Recipe
- Have to use 0.32.1 for doing the build